### PR TITLE
Use exec when starting filebeat

### DIFF
--- a/jobs/filebeat/templates/bin/filebeat_ctl
+++ b/jobs/filebeat/templates/bin/filebeat_ctl
@@ -10,7 +10,6 @@ case $1 in
 
   start)
     pid_guard $PIDFILE $JOB_NAME
-    pid_guard $PIDFILE-init $JOB_NAME-init
 
     chown -R vcap:vcap $STORE_DIR $LOG_DIR $RUN_DIR
 
@@ -23,7 +22,7 @@ case $1 in
     chmod -R g+r /var/vcap/sys/log/*
     find /var/vcap/sys/log -type d -exec chmod g+x {} \;
 
-    chpst -u vcap:vcap /var/vcap/packages/filebeat/bin/filebeat \
+    exec chpst -u vcap:vcap /var/vcap/packages/filebeat/bin/filebeat \
         -c /var/vcap/jobs/filebeat/config/filebeat.yml \
         -path.data $STORE_DIR \
         -path.logs $LOG_DIR \


### PR DESCRIPTION
This fixes an issue where over time multiple filebeat processes can end up running, leading to duplicate shipping of logs.